### PR TITLE
Fix typo on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
           </div>
           <div class="container">
             <span class="download__text" title="After download, you have to unblock the executable.">
-              Exectuable <i class="fa fa-info-circle download__info"></i>
+              Executable <i class="fa fa-info-circle download__info"></i>
             </span>
           </div>
         </a>


### PR DESCRIPTION
`Executable` was written incorrectly. ;)